### PR TITLE
style: enhance karaoke subtitles

### DIFF
--- a/src/edit/subtitles.py
+++ b/src/edit/subtitles.py
@@ -14,12 +14,14 @@ def burn_subtitles_karaoke(
     output_path: str,
     model: str = "tiny",
     font: str = "Inter",
-    font_size: int = 58,
+    font_size: int = 42,
     primary_color: str = "&H00FFFFFF&",  # ASS BGR with &H..& format
+    secondary_color: str = "&H0000FF00&",
     outline_color: str = "&H00000000&",
     outline: int = 3,
     shadow: int = 0,
     margin_bottom: int = 160,
+    margin_lr: int = 100,
 ):
     """
     Transcribe with Whisper (if available) and burn animated karaoke-style subtitles.
@@ -55,7 +57,7 @@ PlayResY: 1920
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Karaoke,{font},{font_size},{primary_color},{primary_color},{outline_color},&H00000000&,0,0,0,0,100,100,0,0,1,{outline},{shadow},2,60,60,{margin_bottom},1
+Style: Karaoke,{font},{font_size},{primary_color},{secondary_color},{outline_color},&H00000000&,0,0,0,0,100,100,0,0,1,{outline},{shadow},2,{margin_lr},{margin_lr},{margin_bottom},1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
@@ -83,11 +85,18 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             w_start = float(w.get('start', prev))
             w_end = float(w.get('end', w_start))
             dur_cs = max(1, int(round((w_end - w_start) * 100)))
-            token = (w.get('word') or w.get('text') or '').strip()
+            token = (w.get('word') or w.get('text') or '')
             # escape braces
             token = token.replace('{', '\\{').replace('}', '\\}')
+            if parts:
+                if not token.startswith(' '):
+                    token = ' ' + token
+            else:
+                token = token.lstrip()
             parts.append(f"{{\\k{dur_cs}}}{token}")
             prev = w_end
+        if len(parts) > 3:
+            parts.insert(len(parts)//2, '\\N')
         payload = ''.join(parts)
         lines.append(f"Dialogue: 0,{ass_time(start)},{ass_time(end)},Karaoke,,0,0,0,,{payload}")
 


### PR DESCRIPTION
## Summary
- refine `burn_subtitles_karaoke` with smaller font, padding and green highlight
- ensure tokens preserve spaces and split long lines for better readability

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf2e802508321b9f6299452126d3b